### PR TITLE
sub-parser can be obtained via indexer using option alias

### DIFF
--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -593,5 +593,48 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             result["command"].Arguments.Should().BeEquivalentTo("argument");
             result.UnmatchedTokens.Should().BeEquivalentTo("/p:RandomThing=random");
         }
+
+        [Fact]
+        public void A_sub_parser_can_be_obtained_by_the_alias_of_the_command()
+        {
+            var parser = new Parser(
+                Command("outer", "",
+                        Command("inner-one", "",
+                                Option("--option-one", "")),
+                        Command("inner-two", "",
+                                Option("--option-two", ""))));
+
+            parser["outer"]
+                .DefinedOptions
+                .Select(o => o.Name)
+                .Should()
+                .BeEquivalentTo("inner-one", "inner-two");
+
+            parser["outer"]["inner-two"]
+                .DefinedOptions
+                .Select(o => o.Name)
+                .Should()
+                .BeEquivalentTo("option-two");
+        }
+
+        [Fact]
+        public void A_sub_parser_has_the_parent_parser_configurations()
+        {
+            var parser = new Parser(
+                new char[0],
+                Command("outer", "",
+                        NoArguments,
+                        Command("inner", "",
+                                ZeroOrMoreArguments)));
+
+            var child = parser["outer"];
+
+            var result = child.Parse("inner /x:this=that");
+
+            result["inner"]
+                .Arguments
+                .Should()
+                .BeEquivalentTo("/x:this=that");
+        }
     }
 }

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -10,9 +10,9 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public class Parser
     {
-        private readonly char[] delimiters = null;
+        private static readonly char[] defaultTokenSplitDelimiters = { '=', ':' };
 
-        public char[] DefaultArgumentSplitDelimiters { get; set; } = { '=', ':' };
+        private readonly char[] tokenSplitDelimiters = null;
 
         public Parser(params Option[] options)
         {
@@ -22,12 +22,12 @@ namespace Microsoft.DotNet.Cli.CommandLine
             }
 
             DefinedOptions.AddRange(options);
-            delimiters = DefaultArgumentSplitDelimiters;
+            tokenSplitDelimiters = defaultTokenSplitDelimiters;
         }
 
         public Parser(char[] delimiters, params Option[] options) : this(options)
         {
-            this.delimiters = delimiters ?? DefaultArgumentSplitDelimiters;
+            tokenSplitDelimiters = delimiters ?? defaultTokenSplitDelimiters;
         }
 
         public OptionSet<Option> DefinedOptions { get; } = new OptionSet<Option>();
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 .Distinct()
                 .ToArray();
 
-            var unparsedTokens = new Queue<string>(Normalize(rawArgs).Lex(validTokens, delimiters));
+            var unparsedTokens = new Queue<string>(Normalize(rawArgs).Lex(validTokens, tokenSplitDelimiters));
             var appliedOptions = new OptionSet<AppliedOption>();
             var errors = new List<OptionError>();
             var unmatchedTokens = new List<string>();
@@ -136,6 +136,9 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             return args;
         }
+
+        public Parser this[string alias] =>
+            new Parser(tokenSplitDelimiters, DefinedOptions[alias].DefinedOptions.ToArray());
 
         private static OptionError UnrecognizedArg(string arg) =>
             new OptionError(


### PR DESCRIPTION
We previously made a change to allow specifying the delimiters for splitting arguments during lexing (#22). Such a configuration would be lost, though, when accessing a parser definition by command-name index.

This change allows more nested parsers to be derived by indexing into a parser rather than into an command or option directly (which is a capability that should perhaps be removed). 

Opinions welcome.

@livarcocc @blackdwarf @piotrpMSFT @eerhardt