### PR TITLE
ParseException with informative error on failed AppliedOption.Value call

### DIFF
--- a/CommandLine.Tests/MaterializerTests.cs
+++ b/CommandLine.Tests/MaterializerTests.cs
@@ -113,6 +113,25 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             result["something"]["x"].Value<bool>().Should().BeFalse();
         }
 
+        [Fact]
+        public void When_a_materializer_throws_then_an_informative_exception_message_is_given()
+        {
+            var command = Command("the-command", "",
+                                  Option("-o|--one", "",
+                                         Accept.ExactlyOneArgument
+                                               .MaterializeAs(o => int.Parse(o.Arguments.Single()))));
+
+            var result = command.Parse("the-command -o not-an-int");
+
+            Action getValue = () => result["the-command"]["one"].Value();
+
+            getValue.ShouldThrow<ParseException>()
+                    .Which
+                    .Message
+                    .Should()
+                    .Be("An exception occurred while getting the value for option 'one' based on argument(s): not-an-int.");
+        }
+
         public class FileMoveOperation
         {
             public List<FileInfo> Files { get; set; }

--- a/CommandLine/AppliedOption.cs
+++ b/CommandLine/AppliedOption.cs
@@ -128,7 +128,22 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
         public T Value<T>() => (T) Value();
 
-        public object Value() => materialize();
+        public object Value()
+        {
+            try
+            {
+                return materialize();
+            }
+            catch (Exception exception)
+            {
+                var argumentsDescription = Arguments.Any()
+                                               ? string.Join(", ", Arguments)
+                                               : " (none)";
+                throw new ParseException(
+                    $"An exception occurred while getting the value for option '{Option.Name}' based on argument(s): {argumentsDescription}.",
+                    exception);
+            }
+        }
 
         public override string ToString() => this.Diagram();
     }

--- a/CommandLine/CommandLine.csproj
+++ b/CommandLine/CommandLine.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Command.cs" />
     <Compile Include="CommandExecutionResult.cs" />
     <Compile Include="IAliased.cs" />
+    <Compile Include="ParseException.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="ParseResultExtensions.cs" />
     <Compile Include="ParserExtensions.cs" />

--- a/CommandLine/ParseException.cs
+++ b/CommandLine/ParseException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Microsoft.DotNet.Cli.CommandLine
+{
+    public class ParseException : Exception
+    {
+        public ParseException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
When a delegate for argument materialization throws, this will wrap it in an informative exception that will specify which option and argument the error occurred on.