### PR TITLE
Invert parser greediness

### DIFF
--- a/CommandLine.Tests/ArgumentsRuleCompositionTests.cs
+++ b/CommandLine.Tests/ArgumentsRuleCompositionTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.CommandLine.Tests
+{
+    public class ArgumentsRuleCompositionTests
+    {
+        [Fact]
+        public void Composed_rule_results_are_equivalent_when_one_is_successful_and_the_other_fails()
+        {
+            var fail = new ArgumentsRule(o => "fail");
+            var succeed = new ArgumentsRule(o => "fail");
+
+            var appliedOption = new AppliedOption(Create.Option("-x", ""));
+
+            fail.And(succeed).Validate(appliedOption).Should().Be("fail");
+            succeed.And(fail).Validate(appliedOption).Should().Be("fail");
+        }
+
+        [Fact]
+        public void The_failure_message_returned_is_the_first_to_fail()
+        {
+            var first = new ArgumentsRule(o => "first error");
+            var second = new ArgumentsRule(o => "second error");
+
+            var appliedOption = new AppliedOption(Create.Option("-x", ""));
+
+            first.And(second).Validate(appliedOption).Should().Be("first error");
+        }
+
+        [Fact]
+        public void Later_rules_are_not_evaluated()
+        {
+            var secondRuleWasCalled = false;
+            var first = new ArgumentsRule(o => "first error");
+            var second = new ArgumentsRule(o =>
+            {
+                secondRuleWasCalled = true;
+                return "second error";
+            });
+
+            var appliedOption = new AppliedOption(Create.Option("-x", ""));
+
+            first.And(second).Validate(appliedOption);
+
+            secondRuleWasCalled.Should().BeFalse();
+        }
+
+    }
+}

--- a/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/CommandLine.Tests/CommandLine.Tests.csproj
@@ -77,6 +77,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AppliedOptionTests.cs" />
+    <Compile Include="ArgumentsRuleCompositionTests.cs" />
     <Compile Include="ParsingValidationTests.cs" />
     <Compile Include="CommandTests.cs" />
     <Compile Include="CommandExecutionTests.cs" />

--- a/CommandLine.Tests/HelpViewTests.cs
+++ b/CommandLine.Tests/HelpViewTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             command["inner"]["inner-er"]
                 .HelpView()
                 .Should()
-                .StartWith("usage: outer inner inner-er [options]");
+                .Contain("Usage: outer inner inner-er [options]");
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
 
             helpView
                 .Should()
-                .Contain("usage: the-command [options] [the-args]");
+                .Contain("Usage: the-command [options] [the-args]");
         }
 
         [Fact]

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -351,6 +351,19 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
+        public void When_a_subcommand_has_a_name_conflict_with_its_uncle_then_the_innermost_subcommand_is_attached_to_the_subcommand()
+        {
+            var command = Command("one", "",
+                                  Command("two", "",
+                                          Command("three", "")),
+                                  Command("three", ""));
+
+            var result = command.Parse("one two three");
+
+            result.Diagram().Should().Be("[ one [ two [ three ] ] ]");
+        }
+
+        [Fact]
         public void When_child_option_will_not_accept_arg_then_parent_can()
         {
             var parser = new Parser(

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -289,6 +289,26 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
+        public void Options_need_not_be_respecified_in_order_to_add_arguments()
+        {
+            var parser = new Parser(
+                Option("-a|--animals", "", ZeroOrMoreArguments()),
+                Option("-v|--vegetables", "", ZeroOrMoreArguments()));
+
+            var result = parser.Parse("-a cat dog -v carrot");
+
+            result["animals"]
+                .Arguments
+                .Should()
+                .BeEquivalentTo("cat", "dog");
+
+            result["vegetables"]
+                .Arguments
+                .Should()
+                .BeEquivalentTo("carrot");
+        }
+
+        [Fact]
         public void Option_with_multiple_nested_options_allowed_is_parsed_correctly()
         {
             var option = Command("outer", "",

--- a/CommandLine.Tests/ParsingValidationTests.cs
+++ b/CommandLine.Tests/ParsingValidationTests.cs
@@ -19,23 +19,6 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void An_error_is_returned_when_multiple_sibling_commands_are_passed()
-        {
-            var option = Command("outer", "",
-                                 Command("inner1", "", ExactlyOneArgument()),
-                                 Command("inner2", "", ExactlyOneArgument()));
-
-            var parser = new Parser(option);
-
-            var result = parser.Parse("outer inner1 argument1 inner2 argument2");
-
-            result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .Contain("Command 'outer' only accepts a single subcommand but 2 were provided: inner1, inner2");
-        }
-
-        [Fact]
         public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
             var parser = new Parser(

--- a/CommandLine/ArgumentsRule.cs
+++ b/CommandLine/ArgumentsRule.cs
@@ -67,6 +67,8 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
         public string Name { get; }
 
+        internal Func<AppliedOption, object> Materializer => materialize;
+
         internal IEnumerable<string> Suggest(ParseResult parseResult) =>
             suggest(parseResult);
 

--- a/CommandLine/ArgumentsRuleExtensions.cs
+++ b/CommandLine/ArgumentsRuleExtensions.cs
@@ -10,19 +10,21 @@ namespace Microsoft.DotNet.Cli.CommandLine
     {
         public static ArgumentsRule And(
             this ArgumentsRule rule,
-            params ArgumentsRule[] rules)
+            ArgumentsRule rule2)
         {
-            rules = new[] { rule }.Concat(rules).ToArray();
+            var rules = new[] { rule, rule2 };
 
             return new ArgumentsRule(
                 validate: option => rules.Select(r => r.Validate(option))
                                          .FirstOrDefault(result => !String.IsNullOrWhiteSpace(result)),
-                allowedValues: rules.SelectMany(r => r.AllowedValues).Distinct().ToArray(),
+                allowedValues: rules.SelectMany(r => r.AllowedValues)
+                                    .Distinct()
+                                    .ToArray(),
                 suggest: result => rules.SelectMany(r => r.Suggest(result)),
-                name: rule.Name,
-                description: rule.Description,
-                defaultValue: rule.GetDefaultValue,
-                materialize: rule.Materialize);
+                name: rule.Name ?? rule2.Name,
+                description: rule.Description ?? rule2.Description,
+                defaultValue: rule.GetDefaultValue ?? rule2.GetDefaultValue,
+                materialize: rule.Materializer ?? rule2.Materializer);
         }
 
         public static ArgumentsRule MaterializeAs<T>(

--- a/CommandLine/CommandLine.csproj
+++ b/CommandLine/CommandLine.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Option.cs" />
     <Compile Include="OptionSet.cs" />
     <Compile Include="Suggest.cs" />
+    <Compile Include="Token.cs" />
+    <Compile Include="TokenType.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/CommandLine/OptionSet.cs
+++ b/CommandLine/OptionSet.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
+    [DebuggerStepThrough]
     public class OptionSet<T> :
         IReadOnlyCollection<T>
         where T : IAliased

--- a/CommandLine/ParseException.cs
+++ b/CommandLine/ParseException.cs
@@ -4,6 +4,10 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public class ParseException : Exception
     {
+        public ParseException(string message) : base(message)
+        {
+        }
+
         public ParseException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/CommandLine/ParseResult.cs
+++ b/CommandLine/ParseResult.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
+    [DebuggerDisplay("{" + nameof(ToString) + "()}")]
     public class ParseResult
     {
         private readonly List<OptionError> errors = new List<OptionError>();

--- a/CommandLine/ParserExtensions.cs
+++ b/CommandLine/ParserExtensions.cs
@@ -30,7 +30,12 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             var s = new StringBuilder();
 
-            s.Append("usage: ");
+            if (!string.IsNullOrWhiteSpace(command.HelpText))
+            {
+                s.AppendLine(command.HelpText);
+            }
+
+            s.Append("Usage: ");
 
             s.Append(command.FullyQualifiedName());
 

--- a/CommandLine/Token.cs
+++ b/CommandLine/Token.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli.CommandLine
+{
+    public class Token
+    {
+        public Token(string value, TokenType type)
+        {
+            Value = value;
+            Type = type;
+        }
+
+        public string Value { get; }
+
+        public TokenType Type { get; }
+
+        public override string ToString()
+        {
+            return $"{Type}: {Value}";
+        }
+    }
+}

--- a/CommandLine/TokenType.cs
+++ b/CommandLine/TokenType.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli.CommandLine
+{
+    public enum TokenType
+    {
+        Argument,
+        Command,
+        Option
+    }
+}

--- a/SampleParsers/Dotnet/DotnetParserHelpTextExamples.cs
+++ b/SampleParsers/Dotnet/DotnetParserHelpTextExamples.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
             this.output = output;
         }
 
-        [Theory]
+        [Theory(Skip="Work in progress")]
         [InlineData("dotnet -h")]
         [InlineData("dotnet add -h")]
         [InlineData("dotnet add package -h")]

--- a/SampleParsers/Dotnet/SuggestionTests.cs
+++ b/SampleParsers/Dotnet/SuggestionTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
                   .BeEquivalentTo("reference", "package", "-h", "--help");
         }
 
-        [Fact(Skip="Bug")]
+        [Fact]
         public void dotnet_sln_add()
         {
             var command = DotnetCommand();


### PR DESCRIPTION
This is a reworking of the core parser and `AppliedOption` logic that changes the greediness behavior to be more intuitive. Inner and farther-right commands or options will now capture arguments more greedily than outer and farther-left arguments. For example, consider the following configuration:

```
Command("outer", "",
    Option("-h|--help", ""),
    Command("inner", "", 
        Option("-h|--help", ""));
```

When parsing `outer inner -h`, the following diagram describes the result prior to this change:

`[ outer [ inner ] [ --help ] ]`

Now, the result will be as follows:

`[ outer [ inner [ --help ] ] ]`


 