### PR TITLE
don't split tokens that look like options but are not

### DIFF
--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void A_double_dash_delimiter_specifies_that_no_further_command_line_args_will_be_treated_options()
+        public void A_double_dash_delimiter_specifies_that_no_further_command_line_args_will_be_treated_as_options()
         {
             var result = new Parser(
                     Option("-o|--one", ""))
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Short_form_arguments_can_be_specified_using_equals_delimiter()
+        public void Short_form_options_can_be_specified_using_equals_delimiter()
         {
             var parser = new Parser(Option("-x", "", ExactlyOneArgument()));
 
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Long_form_arguments_can_be_specified_using_equals_delimiter()
+        public void Long_form_options_can_be_specified_using_equals_delimiter()
         {
             var parser = new Parser(Option("--hello", "", ExactlyOneArgument()));
 
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Short_form_arguments_can_be_specified_using_colon_delimiter()
+        public void Short_form_options_can_be_specified_using_colon_delimiter()
         {
             var parser = new Parser(Option("-x", "", ExactlyOneArgument()));
 
@@ -221,7 +221,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Long_form_arguments_can_be_specified_using_colon_delimiter()
+        public void Long_form_options_can_be_specified_using_colon_delimiter()
         {
             var parser = new Parser(Option("--hello", "", ExactlyOneArgument()));
 
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Argument_short_forms_can_be_bundled()
+        public void Option_short_forms_can_be_bundled()
         {
             var parser = new Parser(
                 Command("the-command", "",
@@ -251,7 +251,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Argument_long_forms_do_not_get_unbundled()
+        public void Option_long_forms_do_not_get_unbundled()
         {
             var parser = new Parser(
                 Command(

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -591,7 +591,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void Absolite_Windows_style_paths_are_lexed_correctly()
+        public void Absolute_Windows_style_paths_are_lexed_correctly()
         {
             var command =
                 @"rm ""c:\temp\the file.txt\""";
@@ -629,14 +629,15 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         {
             var command = Command("command",
                                   "",
-                                  ExactlyOneArgument(),
+                                  OneOrMoreArguments(),
                                   Option("-o", "", NoArguments()));
 
-            var result = command.Parse("command argument -o /p:RandomThing=random",
-                                       new char[0]);
+            var result = command.Parse("command argument -o -p:RandomThing=random");
 
-            result["command"].Arguments.Should().BeEquivalentTo("argument");
-            result.UnmatchedTokens.Should().BeEquivalentTo("/p:RandomThing=random");
+            result["command"]
+                .Arguments
+                .Should()
+                .BeEquivalentTo("argument", "-p:RandomThing=random");
         }
 
         [Fact]
@@ -674,5 +675,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                 .Should()
                 .BeEquivalentTo("one");
         }
+
+
     }
 }

--- a/CommandLine/StringExtensions.cs
+++ b/CommandLine/StringExtensions.cs
@@ -74,11 +74,18 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 {
                     var parts = arg.Split(argumentDelimiters, 2);
 
-                    yield return Option(parts[0]);
-
-                    if (parts.Length > 1)
+                    if (knownTokens.Any(t => t.Value == parts.First()))
                     {
-                        yield return Argument(parts[1]);
+                        yield return Option(parts[0]);
+
+                        if (parts.Length > 1)
+                        {
+                            yield return Argument(parts[1]);
+                        }
+                    }
+                    else
+                    {
+                        yield return Argument(arg);
                     }
                 }
                 else if (arg.CanBeUnbundled(knownTokens))


### PR DESCRIPTION
This addresses https://github.com/dotnet/cli/issues/6124.

It will prevent, for example, `-p:something` from being treated as an option `-p` with argument `something` if `-p` is not a defined option. 