### PR TITLE
change set of tokens considered as options as parse progresses

### DIFF
--- a/CommandLine/OptionExtensions.cs
+++ b/CommandLine/OptionExtensions.cs
@@ -9,25 +9,6 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public static class OptionExtensions
     {
-        internal static IEnumerable<Command> AllCommands(
-            this Command command)
-        {
-            if (command == null)
-            {
-               yield break;
-            }
-
-            yield return command;
-
-            foreach (var item in command
-                .DefinedOptions
-                .FlattenBreadthFirst(o => o.DefinedOptions)
-                .OfType<Command>())
-            {
-                yield return item;
-            }
-        }
-
         internal static IEnumerable<Option> FlattenBreadthFirst(
             this IEnumerable<Option> options)
         {
@@ -42,7 +23,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                   .OfType<Command>()
                   .FirstOrDefault();
 
-        public static bool IsHidden(this Option  option) => 
+        public static bool IsHidden(this Option option) =>
             string.IsNullOrWhiteSpace(option.HelpText);
 
         internal static IEnumerable<AppliedOption> AllOptions(

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -37,20 +37,9 @@ namespace Microsoft.DotNet.Cli.CommandLine
             IReadOnlyCollection<string> rawArgs,
             bool isProgressive)
         {
-            var knownTokens = new HashSet<Token>(
-                DefinedOptions
-                    .FlattenBreadthFirst()
-                    .SelectMany(
-                        o =>
-                            o.RawAliases.Select(
-                                a =>
-                                    new Token(a, o.IsCommand
-                                                     ? TokenType.Command
-                                                     : TokenType.Option))));
-
             var unparsedTokens = new Queue<Token>(
                 NormalizeRootCommand(rawArgs)
-                    .Lex(knownTokens, configuration));
+                    .Lex(configuration));
             var rootAppliedOptions = new AppliedOptionSet();
             var allAppliedOptions = new List<AppliedOption>();
             var errors = new List<OptionError>();

--- a/SampleParsers/Dotnet/DotNetParser.cs
+++ b/SampleParsers/Dotnet/DotNetParser.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
     public static class DotNetParser
     {
         public static Parser Instance = new Parser(
-            delimiters: Array.Empty<char>(),
             options: DotnetCommand());
 
         private static Command DotnetCommand() =>
@@ -65,6 +64,10 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
         private static Command Build() =>
             Command("build",
                     ".NET Builder",
+                    ZeroOrOneArgument()
+                        .With(name: "PROJECT",
+                              description:
+                              "The MSBuild project file to build. If a project file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file."),
                     HelpOption(),
                     Option("-o|--output",
                            "Output directory in which to place built artifacts.",
@@ -388,8 +391,8 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
                     Command("add",
                             ".NET Add project(s) to a solution file Command",
                             OneOrMoreArguments()
-                        .With(name: "args", 
-                                description: "Add one or more specified projects to the solution."),
+                                .With(name: "args",
+                                      description: "Add one or more specified projects to the solution."),
                             HelpOption()),
                     Command("list",
                             "List all projects in the solution.",
@@ -397,8 +400,8 @@ namespace Microsoft.DotNet.Cli.CommandLine.SampleParsers.Dotnet
                     Command("remove",
                             "Remove the specified project(s) from the solution. The project is not impacted.",
                             OneOrMoreArguments()
-                        .With(name: "args", 
-                                description: "Remove the specified project(s) from the solution. The project is not impacted."),
+                                .With(name: "args",
+                                      description: "Remove the specified project(s) from the solution. The project is not impacted."),
                             HelpOption()));
 
         private static Command Test() =>


### PR DESCRIPTION
Prior to this change, all tokens identifiable as options are in scope during the entirety of lexing. With this change, the set of tokens identifiable as options changes as the lexing pass traverses subcommands. This allows the parser to be more selective about what to unbundle or split.