### PR TITLE
require that options be repeated for each additional arg

### DIFF
--- a/CommandLine.Tests/MaterializerTests.cs
+++ b/CommandLine.Tests/MaterializerTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             var command = Command("the-command", "",
                                   Option("-x", "", Accept.ZeroOrMoreArguments()));
 
-            command.Parse("the-command -x arg1 arg2")["the-command"]["x"]
+            command.Parse("the-command -x arg1 -x arg2")["the-command"]["x"]
                    .Value()
                    .ShouldBeEquivalentTo(new[] { "arg1", "arg2" });
 

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -339,7 +339,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
-        public void When_a_Parser_root_option_is_not_respecified_then_the_following_token_is_considered_an_argument_to_the_outer_command()
+        public void When_a_Parser_root_option_is_not_respecified_then_the_following_token_is_unmatched()
         {
             var parser = new Parser(
                 Option("-a|--animals", "", ZeroOrMoreArguments()),

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -70,6 +70,10 @@ namespace Microsoft.DotNet.Cli.CommandLine
                             appliedOption = new AppliedOption(definedOption, token.Value);
                             rootAppliedOptions.Add(appliedOption);
                         }
+                        else
+                        {
+                            appliedOption.OptionWasRespecified();
+                        }
 
                         allAppliedOptions.Add(appliedOption);
 


### PR DESCRIPTION
This addresses https://github.com/dotnet/CliCommandLineParser/issues/54