### PR TITLE
Added a parser config option to prevent unbundling

### DIFF
--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -251,6 +251,45 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
+        public void Options_short_forms_do_not_get_unbundled_if_unbundling_is_turned_off()
+        {
+            var parser = new Parser(
+                false,
+                Command("the-command", "",
+                        Option("-x", "", NoArguments()),
+                        Option("-y", "", NoArguments()),
+                        Option("-z", "", NoArguments()),
+                        Option("-xyz", "", NoArguments())));
+
+            var result = parser.Parse("the-command -xyz");
+
+            result["the-command"]
+                .AppliedOptions
+                .Select(o => o.Name)
+                .Should()
+                .BeEquivalentTo("xyz");
+        }
+
+        [Fact]
+        public void Option_short_forms_get_unbundled_if_unbundling_is_explicitly_turned_on()
+        {
+            var parser = new Parser(
+                true,
+                Command("the-command", "",
+                        Option("-x", "", NoArguments()),
+                        Option("-y", "", NoArguments()),
+                        Option("-z", "", NoArguments())));
+
+            var result = parser.Parse("the-command -xyz");
+
+            result["the-command"]
+                .AppliedOptions
+                .Select(o => o.Name)
+                .Should()
+                .BeEquivalentTo("x", "y", "z");
+        }
+
+        [Fact]
         public void Option_long_forms_do_not_get_unbundled()
         {
             var parser = new Parser(

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -253,14 +253,13 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         [Fact]
         public void Options_short_forms_do_not_get_unbundled_if_unbundling_is_turned_off()
         {
-            var parser = new Parser(
-                false,
-                Command("the-command", "",
+            Command command = Command("the-command", "",
                         Option("-x", "", NoArguments()),
                         Option("-y", "", NoArguments()),
                         Option("-z", "", NoArguments()),
-                        Option("-xyz", "", NoArguments())));
-
+                        Option("-xyz", "", NoArguments()));
+            ParserConfiguration parseConfig = new ParserConfiguration(new Option[] { command }, allowUnbundling: false);
+            var parser = new Parser(parseConfig);
             var result = parser.Parse("the-command -xyz");
 
             result["the-command"]
@@ -268,25 +267,6 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                 .Select(o => o.Name)
                 .Should()
                 .BeEquivalentTo("xyz");
-        }
-
-        [Fact]
-        public void Option_short_forms_get_unbundled_if_unbundling_is_explicitly_turned_on()
-        {
-            var parser = new Parser(
-                true,
-                Command("the-command", "",
-                        Option("-x", "", NoArguments()),
-                        Option("-y", "", NoArguments()),
-                        Option("-z", "", NoArguments())));
-
-            var result = parser.Parse("the-command -xyz");
-
-            result["the-command"]
-                .AppliedOptions
-                .Select(o => o.Name)
-                .Should()
-                .BeEquivalentTo("x", "y", "z");
         }
 
         [Fact]

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -16,15 +16,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
         {
         }
 
-        public Parser(bool unbundle, params Option[] options) : this(new ParserConfiguration(options, allowUnbundling: unbundle))
-        {
-        }
-
         public Parser(char[] delimiters, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters))
-        {
-        }
-
-        public Parser(char[] delimiters, bool unbundle, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters, allowUnbundling: unbundle))
         {
         }
 

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -16,7 +16,15 @@ namespace Microsoft.DotNet.Cli.CommandLine
         {
         }
 
+        public Parser(bool unbundle, params Option[] options) : this(new ParserConfiguration(options, allowUnbundling: unbundle))
+        {
+        }
+
         public Parser(char[] delimiters, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters))
+        {
+        }
+
+        public Parser(char[] delimiters, bool unbundle, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters, allowUnbundling: unbundle))
         {
         }
 

--- a/CommandLine/ParserConfiguration.cs
+++ b/CommandLine/ParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.DotNet.Cli.CommandLine
     {
         public ParserConfiguration(
             IReadOnlyCollection<Option> definedOptions,
-            IReadOnlyCollection<char> argumentDelimiters = null)
+            IReadOnlyCollection<char> argumentDelimiters = null,
+            bool allowUnbundling = true)
         {
             if (definedOptions == null)
             {
@@ -22,10 +23,13 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             DefinedOptions.AddRange(definedOptions);
             ArgumentDelimiters = argumentDelimiters ?? new[] { ':', '=' };
+            AllowUnbundling = allowUnbundling;
         }
 
         public OptionSet DefinedOptions { get; } = new OptionSet();
 
         public IReadOnlyCollection<char> ArgumentDelimiters { get; }
+
+        public bool AllowUnbundling { get; }
     }
 }

--- a/CommandLine/StringExtensions.cs
+++ b/CommandLine/StringExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                         yield return Argument(arg);
                     }
                 }
-                else if (arg.CanBeUnbundled(knownTokens))
+                else if (configuration.AllowUnbundling && arg.CanBeUnbundled(knownTokens))
                 {
                     foreach (var character in arg.Skip(1))
                     {


### PR DESCRIPTION
This will prevent '-xyz' from becoming '-x -y -z' even if they're all valid options.