### PR TITLE
add LegalFilePathsOnly arguments rule

### DIFF
--- a/CommandLine.Tests/ParsingValidationTests.cs
+++ b/CommandLine.Tests/ParsingValidationTests.cs
@@ -100,6 +100,40 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
+        public void LegalFilePathsOnly_rejects_arguments_containing_invalid_path_characters()
+        {
+            var command = Command("the-command", "",
+                                  ZeroOrMoreArguments()
+                                      .LegalFilePathsOnly());
+
+            var invalidPathName = "/t:SomeMsBuildArg";
+            var invalidCharacters = $"|{Path.GetInvalidPathChars().First()}|";
+
+            output.WriteLine(string.Join("\n", Path.GetInvalidPathChars()));
+
+            var result = command.Parse($"the-command {invalidPathName} {invalidCharacters}");
+
+            result.UnmatchedTokens
+                  .Should()
+                  .BeEquivalentTo(invalidPathName, invalidCharacters);
+        }
+
+        [Fact]
+        public void LegalFilePathsOnly_accepts_arguments_containing_valid_path_characters()
+        {
+            var command = Command("the-command", "",
+                                  ZeroOrMoreArguments()
+                                      .LegalFilePathsOnly());
+
+            var validPathName = Directory.GetCurrentDirectory();
+            var validNonExistingFileName = Path.Combine(validPathName, Guid.NewGuid().ToString());
+
+            var result = command.Parse($"the-command {validPathName} {validNonExistingFileName}");
+
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
         public void An_argument_can_be_invalid_based_on_file_existence()
         {
             var command = Command("move", "",

--- a/CommandLine.Tests/ParsingValidationTests.cs
+++ b/CommandLine.Tests/ParsingValidationTests.cs
@@ -106,16 +106,15 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                                   ZeroOrMoreArguments()
                                       .LegalFilePathsOnly());
 
-            var invalidPathName = "/t:SomeMsBuildArg";
             var invalidCharacters = $"|{Path.GetInvalidPathChars().First()}|";
 
             output.WriteLine(string.Join("\n", Path.GetInvalidPathChars()));
 
-            var result = command.Parse($"the-command {invalidPathName} {invalidCharacters}");
+            var result = command.Parse($"the-command {invalidCharacters}");
 
             result.UnmatchedTokens
                   .Should()
-                  .BeEquivalentTo(invalidPathName, invalidCharacters);
+                  .BeEquivalentTo(invalidCharacters);
         }
 
         [Fact]

--- a/CommandLine/Accept.cs
+++ b/CommandLine/Accept.cs
@@ -86,6 +86,29 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 return null;
             }));
 
+        public static ArgumentsRule LegalFilePathsOnly(
+            this ArgumentsRule rule) =>
+            rule.And(new ArgumentsRule(o =>
+            {
+                foreach (var arg in o.Arguments)
+                {
+                    try
+                    {
+                        var fileInfo = new FileInfo(arg);
+                    }
+                    catch (NotSupportedException ex)
+                    {
+                        return ex.Message;
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        return ex.Message;
+                    }
+                }
+
+                return null;
+            }));
+
         public static ArgumentsRule WithSuggestionsFrom(
             params string[] values) =>
             new ArgumentsRule(


### PR DESCRIPTION
This adds a rule that can be used to prevent illegal file paths from being accepted as an argument. Nonexistent files will still be accepted. 

Does the method name adequately express this distinction? Better suggestions?

@seancpeters @livarcocc @piotrpMSFT @polarapfel