### PR TITLE
allow de-prefixed option to have the same name as a sibling command

### DIFF
--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                   .Which
                   .Message
                   .Should()
-                  .Be("Alias 'one' is already in use.");
+                  .Be("Alias '--one' is already in use.");
         }
 
         [Fact]
@@ -760,6 +760,29 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                 .Arguments
                 .Should()
                 .BeEquivalentTo("one");
+        }
+
+        [Fact]
+        public void Option_and_Command_can_have_the_same_alias()
+        {
+            var parser = new Parser(
+                Command("outer", "",
+                        ZeroOrMoreArguments(),
+                        Command("inner", "",
+                                ZeroOrMoreArguments()),
+                        Option("--inner", "")));
+
+            parser.Parse("outer inner")
+                  .AppliedCommand()
+                  .Name
+                  .Should()
+                  .Be("inner");
+
+            parser.Parse("outer --inner")
+                  .AppliedCommand()
+                  .Name
+                  .Should()
+                  .Be("outer");
         }
     }
 }

--- a/CommandLine/OptionSet.cs
+++ b/CommandLine/OptionSet.cs
@@ -6,8 +6,10 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public class OptionSet : OptionSet<Option>
     {
-        public override bool HasAlias(Option option, string alias) => option.HasAlias(alias);
+        public override bool HasAlias(Option option, string alias) =>
+            option.RawAliases.Contains(alias) ||
+            option.Aliases.Contains(alias);
 
-        protected override IReadOnlyCollection<string> AliasesFor(Option option) => option.Aliases;
+        protected override IReadOnlyCollection<string> AliasesFor(Option option) => option.RawAliases;
     }
 }

--- a/CommandLine/OptionSet{T}.cs
+++ b/CommandLine/OptionSet{T}.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
             }
         }
 
-        public T this[string alias] => options.Single(o => HasAlias(o, alias));
+        public T this[string alias] => options.First(o => HasAlias(o, alias));
 
         public int Count => options.Count;
 
@@ -50,31 +50,18 @@ namespace Microsoft.DotNet.Cli.CommandLine
             }
         }
 
-        internal void TryAdd(T option)
-        {
-            if (!ContainsOptionWithAnyAliasOf(option))
-            {
-                options.Add(option);
-            }
-        }
-
         public abstract bool HasAlias(T option, string alias);
-
-        internal bool ContainsOptionWithAnyAliasOf(T option)
-        {
-            return AliasesFor(option)
-                .Any(alias => options
-                         .Any(o => HasAlias(o, alias)));
-        }
 
         internal void Add(T option)
         {
-            foreach (var alias in AliasesFor(option))
+            var preexistingAlias = AliasesFor(option)
+                .FirstOrDefault(alias =>
+                                    options.Any(o =>
+                                                    HasAlias(o, alias)));
+
+            if (preexistingAlias != null)
             {
-                if (options.Any(o => HasAlias(o, alias)))
-                {
-                    throw new ArgumentException($"Alias '{alias}' is already in use.");
-                }
+                throw new ArgumentException($"Alias '{preexistingAlias}' is already in use.");
             }
 
             options.Add(option);


### PR DESCRIPTION
This addresses #63.