### PR TITLE
start help view with usage

### DIFF
--- a/CommandLine.Tests/HelpViewTests.cs
+++ b/CommandLine.Tests/HelpViewTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             ((Command) command["inner"]["inner-er"])
                 .HelpView()
                 .Should()
-                .Contain("Usage: outer inner inner-er [options]");
+                .StartWith("Usage: outer inner inner-er [options]");
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
 
             helpView
                 .Should()
-                .Contain("Usage: the-command [options] <the-args>");
+                .StartWith("Usage: the-command [options] <the-args>");
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
 
             helpView
                 .Should()
-                .Contain("Usage: outer-command <outer-args> inner-command [options] <inner-args>");
+                .StartWith("Usage: outer-command <outer-args> inner-command [options] <inner-args>");
         }
 
         [Fact]
@@ -301,7 +301,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
 
             output.WriteLine(helpView);
 
-            helpView.Should().Contain("Usage: some-command [options] [[--] <additional arguments>...]]");
+            helpView.Should().StartWith("Usage: some-command [options] [[--] <additional arguments>...]]");
         }
 
         [Fact]

--- a/CommandLine/HelpViewExtensions.cs
+++ b/CommandLine/HelpViewExtensions.cs
@@ -19,12 +19,6 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             var helpView = new StringBuilder();
 
-            if (!string.IsNullOrWhiteSpace(command.HelpText))
-            {
-                helpView.AppendLine(command.HelpText);
-                helpView.AppendLine();
-            }
-
             WriteSynopsis(command, helpView);
 
             WriteArgumentsSection(command, helpView);


### PR DESCRIPTION
This change omits the description of the command from the beginning of the help view output. This makes the output more consistent with other command line experiences.

@wul @livarcocc @richlander @billwert