### PR TITLE
add support for implicit root command

### DIFF
--- a/CommandLine.Tests/CommandTests.cs
+++ b/CommandLine.Tests/CommandTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             var command = result.Command();
 
             command.Should().NotBeNull();
-            command.Name.Should().Be("root");
+            command.Name.Should().Be(RootCommand().Name);
         }
 
         [Fact]

--- a/CommandLine.Tests/CommandTests.cs
+++ b/CommandLine.Tests/CommandTests.cs
@@ -158,6 +158,21 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         }
 
         [Fact]
+        public void ParseResult_Command_identifies_implicit_root_command()
+        {
+            var parser1 = new Parser(
+                Option("-x", ""),
+                Option("-y", ""));
+
+            var result = parser1.Parse("-x -y");
+
+            var command = result.Command();
+
+            command.Should().NotBeNull();
+            command.Name.Should().Be("root");
+        }
+
+        [Fact]
         public void ParseResult_AppliedCommand_identifies_the_AppliedOption_for_the_innermost_command()
         {
             var command = Command("outer", "",
@@ -194,7 +209,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             var inner = Command("inner", "");
             var outer = Command("outer", "", inner);
 
-            inner.Command().Should().Be(inner);
+            outer["inner"].Command().Should().Be(inner);
         }
 
         [Fact]

--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -254,10 +254,10 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         public void Options_short_forms_do_not_get_unbundled_if_unbundling_is_turned_off()
         {
             Command command = Command("the-command", "",
-                        Option("-x", "", NoArguments()),
-                        Option("-y", "", NoArguments()),
-                        Option("-z", "", NoArguments()),
-                        Option("-xyz", "", NoArguments()));
+                                      Option("-x", "", NoArguments()),
+                                      Option("-y", "", NoArguments()),
+                                      Option("-z", "", NoArguments()),
+                                      Option("-xyz", "", NoArguments()));
             ParserConfiguration parseConfig = new ParserConfiguration(new Option[] { command }, allowUnbundling: false);
             var parser = new Parser(parseConfig);
             var result = parser.Parse("the-command -xyz");
@@ -807,6 +807,17 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
                   .Name
                   .Should()
                   .Be("outer");
+
+            parser.Parse("outer --inner inner")
+                  .AppliedCommand()
+                  .Name
+                  .Should()
+                  .Be("inner");
+
+            parser.Parse("outer --inner inner")["outer"]
+                  .AppliedOptions
+                  .Should()
+                  .Contain(o => o.Name == "inner");
         }
     }
 }

--- a/CommandLine/AppliedOption.cs
+++ b/CommandLine/AppliedOption.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
         public AppliedOption TryTakeToken(Token token)
         {
             var option = TryTakeArgument(token) ??
-                               TryTakeOptionOrCommand(token);
+                         TryTakeOptionOrCommand(token);
             considerAcceptingAnotherArgument = false;
             return option;
         }
@@ -113,11 +113,12 @@ namespace Microsoft.DotNet.Cli.CommandLine
             if (token.Type == TokenType.Command &&
                 appliedOptions.Any(o => o.Option.IsCommand && !o.HasAlias(token.Value)))
             {
+                // if a subcommand has already been applied, don't accept this one
                 return null;
             }
 
             var applied =
-                appliedOptions.SingleOrDefault(o => o.HasAlias(token.Value));
+                appliedOptions.SingleOrDefault(o => o.Option.HasRawAlias(token.Value));
 
             if (applied != null)
             {

--- a/CommandLine/AppliedOptionSet.cs
+++ b/CommandLine/AppliedOptionSet.cs
@@ -4,8 +4,21 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public class AppliedOptionSet : OptionSet<AppliedOption>
     {
-        public override bool HasAlias(AppliedOption option, string alias) => option.HasAlias(alias);
+        public AppliedOptionSet()
+        {
+        }
 
-        protected override IReadOnlyCollection<string> AliasesFor(AppliedOption option) => option.Aliases;
+        public AppliedOptionSet(IReadOnlyCollection<AppliedOption> options) : base(options)
+        {
+        }
+
+        protected override bool HasAlias(AppliedOption option, string alias) =>
+            option.Option.HasAlias(alias);
+
+        protected override bool HasRawAlias(AppliedOption option, string alias) =>
+            option.Option.HasRawAlias(alias);
+
+        protected override IReadOnlyCollection<string> RawAliasesFor(AppliedOption option) =>
+            option.Option.RawAliases;
     }
 }

--- a/CommandLine/CommandLine.csproj
+++ b/CommandLine/CommandLine.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Runtime.Extensions" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppliedOptionSet.cs" />

--- a/CommandLine/Create.cs
+++ b/CommandLine/Create.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
@@ -54,5 +56,11 @@ namespace Microsoft.DotNet.Cli.CommandLine
             string help,
             params Command[] commands) =>
             new Command(name, help, commands);
+
+        private static readonly Lazy<string> executableName =
+            new Lazy<string>(() => Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
+
+        public static Command RootCommand(params Option[] options) =>
+            Command(executableName.Value, "", Accept.NoArguments(), options);
     }
 }

--- a/CommandLine/Option.cs
+++ b/CommandLine/Option.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
         private readonly HashSet<string> aliases = new HashSet<string>();
 
         private readonly Suggest suggest;
+        private readonly HashSet<string> rawAliases;
 
         public Option(
             string[] aliases,
@@ -42,7 +43,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 throw new ArgumentException("An option alias cannot be null, empty, or consist entirely of whitespace.");
             }
 
-            RawAliases = aliases;
+            rawAliases = new HashSet<string>(aliases);
 
             foreach (var alias in aliases)
             {
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
         public IReadOnlyCollection<string> Aliases => aliases.ToArray();
 
-        public IReadOnlyCollection<string> RawAliases { get; }
+        public IReadOnlyCollection<string> RawAliases => rawAliases.ToArray();
 
         protected internal virtual IReadOnlyCollection<string> AllowedValues { get; }
 
@@ -97,7 +98,9 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
         public Option Parent { get; protected internal set; }
 
-        public bool HasAlias(string s) => aliases.Contains(s.RemovePrefix());
+        public bool HasAlias(string alias) => aliases.Contains(alias.RemovePrefix());
+
+        public bool HasRawAlias(string alias) => rawAliases.Contains(alias);
 
         public Option this[string alias] => DefinedOptions[alias];
 

--- a/CommandLine/OptionSet.cs
+++ b/CommandLine/OptionSet.cs
@@ -6,10 +6,13 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     public class OptionSet : OptionSet<Option>
     {
-        public override bool HasAlias(Option option, string alias) =>
-            option.RawAliases.Contains(alias) ||
-            option.Aliases.Contains(alias);
+        protected override bool HasAlias(Option option, string alias) =>
+            option.HasAlias(alias);
 
-        protected override IReadOnlyCollection<string> AliasesFor(Option option) => option.RawAliases;
+        protected override bool HasRawAlias(Option option, string alias) =>
+            option.HasRawAlias(alias);
+
+        protected override IReadOnlyCollection<string> RawAliasesFor(Option option) =>
+            option.RawAliases;
     }
 }

--- a/CommandLine/ParseResult.cs
+++ b/CommandLine/ParseResult.cs
@@ -11,28 +11,26 @@ namespace Microsoft.DotNet.Cli.CommandLine
     [DebuggerDisplay("{" + nameof(ToString) + "()}")]
     public class ParseResult
     {
+        private readonly ParserConfiguration configuration;
         private readonly List<OptionError> errors = new List<OptionError>();
+        private Command command;
 
         internal ParseResult(
             IReadOnlyCollection<string> tokens,
             AppliedOptionSet appliedOptions,
             bool isProgressive,
+            ParserConfiguration configuration,
             IReadOnlyCollection<string> unparsedTokens = null,
             IReadOnlyCollection<string> unmatchedTokens = null,
             IReadOnlyCollection<OptionError> errors = null)
         {
-            if (tokens == null)
-            {
-                throw new ArgumentNullException(nameof(tokens));
-            }
+            Tokens = tokens ??
+                     throw new ArgumentNullException(nameof(tokens));
+            AppliedOptions = appliedOptions ??
+                             throw new ArgumentNullException(nameof(appliedOptions));
+            this.configuration = configuration ??
+                                 throw new ArgumentNullException(nameof(configuration));
 
-            if (appliedOptions == null)
-            {
-                throw new ArgumentNullException(nameof(appliedOptions));
-            }
-
-            Tokens = tokens;
-            AppliedOptions = appliedOptions;
             IsProgressive = isProgressive;
             UnparsedTokens = unparsedTokens;
             UnmatchedTokens = unmatchedTokens;
@@ -59,6 +57,12 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
         public AppliedOption this[string alias] => AppliedOptions[alias];
 
+        public Command Command() =>
+            command ??
+            (command = configuration.RootCommandIsImplicit
+                           ? configuration.DefinedOptions.OfType<Command>().Single()
+                           : AppliedOptions.Command());
+
         private void CheckForErrors()
         {
             foreach (var option in AppliedOptions.FlattenBreadthFirst())
@@ -71,7 +75,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 }
             }
 
-            var command = this.Command();
+            var command = Command();
 
             if (command != null &&
                 command.DefinedOptions.Any(o => o.IsCommand))

--- a/CommandLine/ParseResultExtensions.cs
+++ b/CommandLine/ParseResultExtensions.cs
@@ -27,10 +27,6 @@ namespace Microsoft.DotNet.Cli.CommandLine
             return source.UnmatchedTokens.LastOrDefault() ?? "";
         }
 
-        public static Command Command(this ParseResult result) =>
-            result.AppliedOptions
-                  .Command();
-
         internal static Command Command(this AppliedOptionSet options) =>
             options.FlattenBreadthFirst()
                    .Select(a => a.Option)

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
         {
             if (configuration.RootCommandIsImplicit)
             {
-                args = new[] { "root" }.Concat(args).ToArray();
+                args = new[] { configuration.RootCommand.Name }.Concat(args).ToArray();
             }
 
             var firstArg = args.FirstOrDefault();

--- a/CommandLine/ParserConfiguration.cs
+++ b/CommandLine/ParserConfiguration.cs
@@ -23,11 +23,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             if (definedOptions.All(o => !o.IsCommand))
             {
-                RootCommand = Create.Command(
-                    "root",
-                    "",
-                    Accept.NoArguments(),
-                    definedOptions.ToArray());
+                RootCommand = Create.RootCommand(definedOptions.ToArray());
                 DefinedOptions.Add(RootCommand);
             }
             else

--- a/CommandLine/ParserConfiguration.cs
+++ b/CommandLine/ParserConfiguration.cs
@@ -21,7 +21,20 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 throw new ArgumentException("You must specify at least one option.");
             }
 
-            DefinedOptions.AddRange(definedOptions);
+            if (definedOptions.All(o => !o.IsCommand))
+            {
+                RootCommand = Create.Command(
+                    "root",
+                    "",
+                    Accept.NoArguments(),
+                    definedOptions.ToArray());
+                DefinedOptions.Add(RootCommand);
+            }
+            else
+            {
+                DefinedOptions.AddRange(definedOptions);
+            }
+
             ArgumentDelimiters = argumentDelimiters ?? new[] { ':', '=' };
             AllowUnbundling = allowUnbundling;
         }
@@ -31,5 +44,9 @@ namespace Microsoft.DotNet.Cli.CommandLine
         public IReadOnlyCollection<char> ArgumentDelimiters { get; }
 
         public bool AllowUnbundling { get; }
+
+        internal Option RootCommand { get; }
+
+        internal bool RootCommandIsImplicit => RootCommand != null;
     }
 }


### PR DESCRIPTION
This adds support for implicit root commands for when a `Parser` is created without subcommands. It allows materialization to behave more consistently.
