### PR TITLE
Add back old overload for now with obsolete attribute

### DIFF
--- a/CommandLine/Create.cs
+++ b/CommandLine/Create.cs
@@ -16,6 +16,14 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 aliases.Split(
                     new[] { '|', ' ' }, StringSplitOptions.RemoveEmptyEntries), help, arguments);
 
+      [Obsolete("Do not use this overload. It will be removed. materialize argument is unused.", error: true)]
+      public static Option Option(
+            string aliases,
+            string help,
+            ArgumentsRule arguments,
+            Func<AppliedOption, object> materialize) =>
+            Option(aliases, help, arguments);
+
         public static Command Command(
             string name,
             string help) =>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value=".nuget\packages" />
+    <add key="globalPackagesFolder" value=".nuget\packages" />
+  </config>
+</configuration>

--- a/build.cmd
+++ b/build.cmd
@@ -3,5 +3,5 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-powershell -NoProfile -NoLogo -Command "& \"%~dp0build.ps1\" %*; exit $LastExitCode;"
+powershell -ExecutionPolicy Bypass -NoProfile -NoLogo -Command "& \"%~dp0build.ps1\" %*; exit $LastExitCode;"
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
This is to allow upgrading the command line parser in the CLI while the templating engine still uses the old one. The overload the templating engine was compiled against must exist. Once we upgrade, then they can upgrade too, and then we can remove the overload.

Also adjusted the build.cmd script to bypass the powershell execution policy as we do now just about everywhere else.

@jonsequitur 