### PR TITLE
Fix handling of tokens following a double dash.

### DIFF
--- a/CommandLine.Tests/ParserTests.cs
+++ b/CommandLine.Tests/ParserTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
         {
             var result = new Parser(
                     Option("-o|--one", ""))
-                .Parse("-o \"some stuff\" -- -x -y -z");
+                .Parse("-o \"some stuff\" -- -x -y -z -o:foo");
 
             result.HasOption("o")
                   .Should()
@@ -148,6 +148,10 @@ namespace Microsoft.DotNet.Cli.CommandLine.Tests
             result.AppliedOptions
                   .Should()
                   .HaveCount(1);
+
+            result.UnparsedTokens
+                  .Should()
+                  .HaveCount(4);
         }
 
         [Fact]

--- a/CommandLine/Parser.cs
+++ b/CommandLine/Parser.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
             {
                 var token = unparsedTokens.Dequeue();
 
-                if (token.Value == "--")
+                if (token.Type == TokenType.EndOfArguments)
                 {
                     // stop parsing further tokens
                     break;

--- a/CommandLine/StringExtensions.cs
+++ b/CommandLine/StringExtensions.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
             ParserConfiguration configuration)
         {
             Option currentCommand = null;
+            bool foundEndOfArguments = false;
 
             var argumentDelimiters = configuration.ArgumentDelimiters.ToArray();
 
@@ -63,6 +64,18 @@ namespace Microsoft.DotNet.Cli.CommandLine
 
             foreach (var arg in args)
             {
+                if (foundEndOfArguments)
+                {
+                    yield return Operand(arg);
+                    continue;
+                }
+                else if (arg == "--")
+                {
+                    yield return EndOfArguments();
+                    foundEndOfArguments = true;
+                    continue;
+                }
+
                 var argHasPrefix = HasPrefix(arg);
 
                 if (argHasPrefix && HasDelimiter(arg))
@@ -120,6 +133,10 @@ namespace Microsoft.DotNet.Cli.CommandLine
         private static Token Command(string value) => new Token(value, TokenType.Command);
 
         private static Token Option(string value) => new Token(value, TokenType.Option);
+
+        private static Token EndOfArguments() => new Token("--", TokenType.EndOfArguments);
+
+        private static Token Operand(string value) => new Token(value, TokenType.Operand);
 
         private static bool CanBeUnbundled(
             this string arg,

--- a/CommandLine/TokenType.cs
+++ b/CommandLine/TokenType.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.Cli.CommandLine
     {
         Argument,
         Command,
-        Option
+        Option,
+        EndOfArguments,
+        Operand
     }
 }


### PR DESCRIPTION
This commit prevents the parser from processing any tokens that follow a
double dash.  Previously, the parser would try to match the tokens
against acceptable arguments and options to the current command
following the double dash.  This may result in modified tokens being
returned from the lex operation when the expected behavior is to leave
the tokens unmodified.

The fix is for the lex operation to keep track of whether or not a
double dash was encountered and, if so, return "unparsed" tokens for the
remaining tokens.

This fixes [CLI #7863](https://github.com/dotnet/cli/issues/7863).