### PR TITLE
Onboard with async publishing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -3,13 +3,16 @@ trigger:
 
 variables:
   teamName: Roslyn-Project-System
+  _DotNetArtifactsCategory: .NETCore
   ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     PB_PublishBlobFeedKey:
     PB_PublishBlobFeedUrl:
+    _PublishUsingPipelines: false
     _DotNetPublishToBlobFeed: false
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     PB_PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
     _DotNetPublishToBlobFeed: true
+    _PublishUsingPipelines: true
 
 phases:
 - template: /eng/build.yml
@@ -76,6 +79,7 @@ phases:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/phases/publish-build-assets.yml
     parameters:
+      publishUsingPipelines: true
       dependsOn:
         - Windows_NT
       queue:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -26,6 +26,8 @@ phases:
         _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                   /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
                   /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                   /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                   /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                   /p:PB_PublishType=$(_PublishType)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2444

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dnceng.visualstudio.com/internal/_build/results?buildId=151211
Test release: https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=4496