### PR TITLE
Enable arcade-powered source-build.

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,23 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>cliCommandLineParser</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+  <Target Name="ApplySourceBuildPatchFiles"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="Execute">
+    <ItemGroup>
+      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
+    </ItemGroup>
+
+    <Exec
+      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      WorkingDirectory="$(RepoRoot)"
+      Condition="'@(SourceBuildPatchFile)' != ''" />
+  </Target>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19207.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>b1f9e12fe3ee71c48ea60b15968745850ac0a4a7</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/source-build-patches/0001-Remove-test-and-sample-projects-from-solution.patch
+++ b/eng/source-build-patches/0001-Remove-test-and-sample-projects-from-solution.patch
@@ -1,0 +1,63 @@
+From fc9b0cac419453b28678689d670e4fc6e09fa143 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 6 Feb 2019 12:18:47 -0600
+Subject: [PATCH] Remove test and sample projects from solution.
+
+---
+ CommandLine.sln | 25 -------------------------
+ 1 file changed, 25 deletions(-)
+
+diff --git a/CommandLine.sln b/CommandLine.sln
+index c3daba4..46b1717 100644
+--- a/CommandLine.sln
++++ b/CommandLine.sln
+@@ -5,18 +5,8 @@ VisualStudioVersion = 15.0.27130.2026
+ MinimumVisualStudioVersion = 10.0.40219.1
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "source", "source", "{865D4F45-B1AF-4C87-AE1A-AA5ADF6D386D}"
+ EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{68E3F6FF-C6EF-4B0D-A9F5-2BE6930C55C0}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "xamples", "xamples", "{C375C10F-04DD-4F64-A8BE-11BDBD0B0546}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandLine", "src\source\CommandLine\Microsoft.DotNet.Cli.CommandLine.csproj", "{7F320A3C-A74A-4EDD-92EC-A8A906047A21}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandLine.Tests", "src\tests\CommandLine.Tests\Microsoft.DotNet.Cli.CommandLine.Tests.csproj", "{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet", "src\xamples\dotnet\dotnet.csproj", "{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandLine.SampleParsers", "src\xamples\SampleParsers\CommandLine.SampleParsers.csproj", "{CD03109D-3909-4B66-9E59-1125F8197193}"
+-EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Any CPU = Debug|Any CPU
+@@ -27,27 +17,12 @@ Global
+ 		{7F320A3C-A74A-4EDD-92EC-A8A906047A21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{7F320A3C-A74A-4EDD-92EC-A8A906047A21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{7F320A3C-A74A-4EDD-92EC-A8A906047A21}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{CD03109D-3909-4B66-9E59-1125F8197193}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{CD03109D-3909-4B66-9E59-1125F8197193}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{CD03109D-3909-4B66-9E59-1125F8197193}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{CD03109D-3909-4B66-9E59-1125F8197193}.Release|Any CPU.Build.0 = Release|Any CPU
+ 	EndGlobalSection
+ 	GlobalSection(SolutionProperties) = preSolution
+ 		HideSolutionNode = FALSE
+ 	EndGlobalSection
+ 	GlobalSection(NestedProjects) = preSolution
+ 		{7F320A3C-A74A-4EDD-92EC-A8A906047A21} = {865D4F45-B1AF-4C87-AE1A-AA5ADF6D386D}
+-		{2614A1E7-E8CC-4A22-96A9-ACED9A18E2C3} = {68E3F6FF-C6EF-4B0D-A9F5-2BE6930C55C0}
+-		{C93310CF-0A00-4A62-BDA2-596FAAE2B1DB} = {C375C10F-04DD-4F64-A8BE-11BDBD0B0546}
+-		{CD03109D-3909-4B66-9E59-1125F8197193} = {C375C10F-04DD-4F64-A8BE-11BDBD0B0546}
+ 	EndGlobalSection
+ 	GlobalSection(ExtensibilityGlobals) = postSolution
+ 		SolutionGuid = {E30B46C8-E7A1-4648-B6E5-416E8DD93857}
+-- 
+2.18.0
+


### PR DESCRIPTION
This enables source-build to support building the entire .NET SDK from
source.  See
https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/README.md
for more details.