### PR TITLE
Fix broken official CI builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,18 +15,19 @@ variables:
     _DotNetPublishToBlobFeed: true
     _PublishUsingPipelines: true
 
-phases:
+jobs:
 - template: /eng/build.yml
   parameters:
     agentOs: Windows_NT
-    queue:
+    pool:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         name: Hosted VS2017
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        name: DotNetCore-Windows
+        name: NetCoreInternal-Pool
+        queue: BuildPool.Server.Amd64.VS2017
         demands:
-        - agent.os -equals Windows_NT        
-      parallel: 2
+        - agent.os -equals Windows_NT
+    strategy:
       matrix:
         ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
           Build_Debug:
@@ -42,28 +43,19 @@ phases:
             _PublishType: blob
             _SignType: real
 
-- template: /eng/common/templates/jobs/jobs.yml
+- template: /eng/common/templates/job/source-build.yml
   parameters:
-    agentOs: Linux_Source_Build
-    queue:
-      name: DotNetCore-Linux
-      parallel: 2
-      matrix:
-        Build_Release:
-          _BuildConfig: Release
-          _PublishType: none
-          _SignType: real
-    variables:
-      _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
-    enableSourceBuild: true
+    platform:
+      name: Managed
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
 
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - template: /eng/build.yml
     parameters:
       agentOs: Linux
-      queue: 
+      pool: 
         name: DotNetCore-Linux
-        parallel: 2
+      strategy:
         matrix:
           Build_Debug:
             _BuildConfig: Debug
@@ -73,15 +65,14 @@ phases:
             _BuildConfig: Release
             _PublishType: none
             _SignType: test
-      variables:
-        _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+      _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
   - template: /eng/build.yml
     parameters:
       agentOs: Darwin
-      queue: 
+      pool: 
         name: Hosted macOS
-        parallel: 2
+      strategy:
         matrix:
           Build_Debug:
             _BuildConfig: Debug
@@ -93,10 +84,11 @@ phases:
             _SignType: test
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/phases/publish-build-assets.yml
+  - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
       publishUsingPipelines: true
       dependsOn:
         - Windows_NT
-      queue:
+        - Source_Build_Managed
+      pool:
         name: Hosted VS2017

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -1,46 +1,50 @@
 parameters:
   agentOs: ''
-  queue: {}
-  variables: {}
+  pool: {}
+  strategy: ''
+  _PREVIEW_VSTS_DOCKER_IMAGE: ''
 
-phases:
-- template: /eng/common/templates/phases/base.yml
+jobs:
+- template: /eng/common/templates/job/job.yml
   parameters:
     name: ${{ parameters.agentOs }}
     enableTelemetry: true
     enableMicrobuild: true
-    publicBuildReasons: PullRequest
-    queue: ${{ parameters.queue }}
+    pool: ${{ parameters.pool }}
+    strategy: ${{ parameters.strategy }}
     variables: 
-      ${{ insert }}: ${{ parameters.variables }}
-      _HelixType: build/product
-      _HelixBuildConfig: $(_BuildConfig)
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        _HelixSource: pr/dotnet/CliCommandLineParser/$(Build.SourceBranch)
-        _OfficialBuildIdArgs: ''
-        _PublishArgs: ''
-        _SignArgs: ''
-      ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        _HelixSource: official/dotnet/CliCommandLineParser/$(Build.SourceBranch)
-        _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                  /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
-                  /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
-                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                  /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                  /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                  /p:PB_PublishType=$(_PublishType)
-        _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+      - _PREVIEW_VSTS_DOCKER_IMAGE: ${{ parameters._PREVIEW_VSTS_DOCKER_IMAGE }}
+      - _HelixType: build/product
+      - _HelixBuildConfig: $(_BuildConfig)
+      - _WindowsAssestManifestName: Windows_NT-AnyCPU.xml
+      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        - _HelixSource: pr/dotnet/CliCommandLineParser/$(Build.SourceBranch)
+        - _OfficialBuildIdArgs: ''
+        - _PublishArgs: ''
+        - _SignArgs: ''
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+        - _HelixSource: official/dotnet/CliCommandLineParser/$(Build.SourceBranch)
+        - _OfficialBuildIdArgs: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+        - _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                        /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
+                        /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                        /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                        /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                        /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                        /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                        /p:PB_PublishType=$(_PublishType)
+        - _SignArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
 
     steps:
+    - checkout: self
+      clean: true
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
       - task: AzureKeyVault@1
         inputs:
           azureSubscription: 'HelixProd_KeyVault'
           KeyVaultName: HelixProdKV
           SecretsFilter: 'HelixApiAccessToken'
-        condition: always()        
+        condition: always()
       - task: AzureKeyVault@1
         inputs:
           azureSubscription: 'DotNet-Engineering-Services_KeyVault'
@@ -49,7 +53,7 @@ phases:
         condition: succeeded()
 
     - ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
-      - script: eng\common\CIBuild.cmd 
+      - script: eng\CIBuild.cmd
                   -configuration %BuildConfig%
                   $(_PublishArgs)
                   $(_SignArgs)

--- a/eng/cibuild.cmd
+++ b/eng/cibuild.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+@REM install the 2.1.0 runtime for running tests
+powershell -ExecutionPolicy ByPass -command "& """%~dp0common\dotnet-install.ps1""" -runtime dotnet -version 2.1.0"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+powershell -ExecutionPolicy ByPass -command "& """%~dp0common\Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
+exit /b %errorlevel%


### PR DESCRIPTION
Related to #183 

Because of https://github.com/dotnet/arcade/issues/7493, I was forced to update the pipeline to the stages schema in order to be able to reference a helix pool.

cc @wli3, @crummel 