### PR TITLE
Remove installation of runtime 2.1.0 from build.sh

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -65,7 +65,7 @@ jobs:
             _BuildConfig: Release
             _PublishType: none
             _SignType: test
-      _PREVIEW_VSTS_DOCKER_IMAGE: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+      _PREVIEW_VSTS_DOCKER_IMAGE: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
   - template: /eng/build.yml
     parameters:

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-# install the 2.1.0 runtime for running tests
-"$ScriptRoot/eng/common/dotnet-install.sh"  -runtime dotnet -version 2.1.0
-
 . "$ScriptRoot/eng/common/build.sh" --build --restore $@

--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "tools": {
-    "dotnet": "5.0.201"
+    "dotnet": "5.0.201",
+    "runtimes": {
+      "dotnet": [
+        "2.1.0"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21256.3"


### PR DESCRIPTION
Installation of another runtime in build.sh doesn't work for source-build when building offline.