### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,10 +23,8 @@ jobs:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         name: Hosted VS2017
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Server.Amd64.VS2017
-        demands:
-        - agent.os -equals Windows_NT
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2017
     strategy:
       matrix:
         ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
Moves the pipeline from old Helix based pools to 1ES hosted pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276